### PR TITLE
Add Atom One Dark theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 elm-stuff
+.DS_Store
+demo/elm.js

--- a/README.md
+++ b/README.md
@@ -28,3 +28,14 @@ view model =
                 (pre [] [ code [] [ text model.elmCode ]])
 		]
 ```
+
+### Running demo
+
+To run demo locally you have to have `elm-live` installed.
+
+```shell
+cd demo
+make start
+```
+
+Demo will be available at http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Syntax highlighting in Elm. [Demo](https://pablohirafuji.github.io/elm-syntax-highlight/).
 
+## Running demo
+
+To run demo locally you have to have [elm-live](https://github.com/tomekwi/elm-live) installed.
+
+```shell
+cd demo
+make start
+```
+
+Demo will be available at http://localhost:8000
+
 
 ## Themes
 
@@ -28,14 +39,3 @@ view model =
                 (pre [] [ code [] [ text model.elmCode ]])
 		]
 ```
-
-### Running demo
-
-To run demo locally you have to have `elm-live` installed.
-
-```shell
-cd demo
-make start
-```
-
-Demo will be available at http://localhost:8000

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,0 +1,7 @@
+start:
+	elm-live Main.elm \
+	 --output=elm.js \
+	 --pushstate \
+	 --open \
+	 --debug \
+	 --dir=./

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,112 +1,112 @@
 <!DOCTYPE html>
 <html>
-<head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>Elm Syntax Highlight</title>
-	<style type="text/css">
-		body {
-			margin: 40px auto;
-			max-width: 650px;
-			line-height: 1.6;
-			font-size: 18px;
-			color: #444;
-			padding: 0 10px;
-			text-align: center;
-		}
-		h1,h2,h3 {
-			line-height: 1.2
-		}
-		h1 {
-			padding-bottom: 0;
-			margin-bottom: 0;
-		}
-		.subheading {
-			margin-top: 0;
-		}
-		ul {
-			text-align: left;
-		}
-		.container {
-			position: relative;
-			overflow: hidden;
-			padding: 0;
-			margin: 0;
-			text-align: left;
-		}
-		.textarea, .view-container {
-			box-sizing: border-box;
-			font-size: 1rem;
-			line-height: 1.2;
-			width: 100%;
-			height: 100%;
-			height: 250px;
-			font-family: monospace;
-			letter-spacing: normal;
-			word-spacing: normal;
-			padding: 0;
-			margin: 0;
-			border: 0;
-			background: transparent;
-			white-space: pre;
-		}
-		.textarea {
-			color: rgba(0,0,0,0);
-			resize: none;
-			z-index: 2;
-			position: relative;
-			padding: 10px;
-		}
-		.textarea-lc {
-			padding-left: 70px;
-		}
-		.textarea:focus {
-			outline: none;
-		}
-		.view-container {
-			position: absolute;
-			top: 0;
-			left: 0;
-			pointer-events: none;
-			z-index:1;
-		}
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<title>Elm Syntax Highlight</title>
+		<style type="text/css">
+			body {
+				margin: 40px auto;
+				max-width: 650px;
+				line-height: 1.6;
+				font-size: 18px;
+				color: #444;
+				padding: 0 10px;
+				text-align: center;
+			}
+			h1,h2,h3 {
+				line-height: 1.2
+			}
+			h1 {
+				padding-bottom: 0;
+				margin-bottom: 0;
+			}
+			.subheading {
+				margin-top: 0;
+			}
+			ul {
+				text-align: left;
+			}
+			.container {
+				position: relative;
+				overflow: hidden;
+				padding: 0;
+				margin: 0;
+				text-align: left;
+			}
+			.textarea, .view-container {
+				box-sizing: border-box;
+				font-size: 1rem;
+				line-height: 1.2;
+				width: 100%;
+				height: 100%;
+				height: 250px;
+				font-family: monospace;
+				letter-spacing: normal;
+				word-spacing: normal;
+				padding: 0;
+				margin: 0;
+				border: 0;
+				background: transparent;
+				white-space: pre;
+			}
+			.textarea {
+				color: rgba(0,0,0,0);
+				resize: none;
+				z-index: 2;
+				position: relative;
+				padding: 10px;
+			}
+			.textarea-lc {
+				padding-left: 70px;
+			}
+			.textarea:focus {
+				outline: none;
+			}
+			.view-container {
+				position: absolute;
+				top: 0;
+				left: 0;
+				pointer-events: none;
+				z-index:1;
+			}
 
-		/* Elm Syntax Highlight CSS */
-		pre.elmsh {
-			padding: 10px;
-			margin: 0;
-			text-align: left;
-			overflow: auto;
-		}
-		code.elmsh {
-			padding: 0;
-		}
-		.elmsh-line:before {
-			content: attr(data-elmsh-lc);
-			display: inline-block;
-			text-align: right;
-			width: 40px;
-			padding: 0 20px 0 0;
-			opacity: 0.3;
-		}
+			/* Elm Syntax Highlight CSS */
+			pre.elmsh {
+				padding: 10px;
+				margin: 0;
+				text-align: left;
+				overflow: auto;
+			}
+			code.elmsh {
+				padding: 0;
+			}
+			.elmsh-line:before {
+				content: attr(data-elmsh-lc);
+				display: inline-block;
+				text-align: right;
+				width: 40px;
+				padding: 0 20px 0 0;
+				opacity: 0.3;
+			}
 
-		/* Demo specifics */
-		pre.elmsh {
-			overflow: visible;
-		}
-	</style>
-</head>
-<body>
-	<h1>Elm Syntax Highlight</h1>
-	<p class="subheading"><!-- <a href="http://package.elm-lang.org/packages/pablohirafuji/elm-syntax-highlight/latest">Package</a> /  --><a href="https://github.com/pablohirafuji/elm-syntax-highlight">GitHub</a> / <a href="https://github.com/pablohirafuji/elm-syntax-highlight/blob/master/demo/Main.elm">Source</a></p>
-	<div id="main"><h2>Loading...</h2></div>
-	<script src="/_compile/Main.elm"></script>
-	<script>
+			/* Demo specifics */
+			pre.elmsh {
+				overflow: visible;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>Elm Syntax Highlight</h1>
+		<p class="subheading"><!-- <a href="http://package.elm-lang.org/packages/pablohirafuji/elm-syntax-highlight/latest">Package</a> /  --><a href="https://github.com/pablohirafuji/elm-syntax-highlight">GitHub</a> / <a href="https://github.com/pablohirafuji/elm-syntax-highlight/blob/master/demo/Main.elm">Source</a></p>
+		<div id="main"><h2>Loading...</h2></div>
+		<script src="elm.js"></script>
+		<script>
 		var node = document.getElementById('main');
 		while (node.firstChild) {
-				node.removeChild(node.firstChild);
+  		node.removeChild(node.firstChild);
 		}
 		var app = Elm.Main.embed(node);
-	</script>
-</body>
+		</script>
+	</body>
 </html>

--- a/src/SyntaxHighlight.elm
+++ b/src/SyntaxHighlight.elm
@@ -9,6 +9,7 @@ module SyntaxHighlight
         , useTheme
         , monokai
         , github
+        , oneDark
         )
 
 {-| Syntax highlighting in Elm.
@@ -23,7 +24,7 @@ module SyntaxHighlight
 
 ## Themes
 
-@docs Theme, useTheme, monokai, github
+@docs Theme, useTheme, monokai, github, oneDark
 
 -}
 
@@ -103,3 +104,10 @@ monokai =
 github : Theme
 github =
     Theme Theme.github
+
+
+{-| Atom One Dark inspired theme.
+-}
+oneDark : Theme
+oneDark =
+    Theme Theme.oneDark

--- a/src/SyntaxHighlight/Theme.elm
+++ b/src/SyntaxHighlight/Theme.elm
@@ -2,6 +2,7 @@ module SyntaxHighlight.Theme
     exposing
         ( monokai
         , github
+        , oneDark
         )
 
 -- Monokai inspired theme
@@ -120,4 +121,81 @@ github =
 
 .elmsh7 {
     color: #795da3;
+}"""
+
+
+
+{-
+   Atom One Dark inspired theme
+   https://github.com/atom/one-dark-syntax
+
+   base:    #282c34
+   mono-1:  #abb2bf
+   mono-2:  #818896
+   mono-3:  #5c6370
+   hue-1:   #56b6c2
+   hue-2:   #61aeee
+   hue-3:   #c678dd
+   hue-4:   #98c379
+   hue-5:   #e06c75
+   hue-5-2: #be5046
+   hue-6:   #d19a66
+   hue-6-2: #e6c07b
+-}
+
+
+oneDark : String
+oneDark =
+    """
+.elmsh {
+  background: #282c34;
+  color: #abb2bf;
+}
+
+.elmsh-hl {
+  background: rgba(229,231,235, 0.1);
+}
+
+.elmsh-add {
+  background: rgba(40,124,82, 0.4);
+}
+
+.elmsh-del {
+  background: rgba(136,64,67, 0.4);
+}
+
+.elmsh-strong {
+  font-weight: bold;
+}
+
+.elmsh-emphasis {
+  font-style: italic;
+}
+
+.elmsh1 {
+  color: #5c6370;
+  font-style: italic
+}
+.elmsh2 {
+  color: #98c379;
+}
+
+.elmsh3 {
+  color: #c678dd;
+}
+
+.elmsh4 {
+  color: #c678dd;
+}
+
+.elmsh5 {
+  color: #61aeee;
+}
+
+.elmsh6 {
+  color: #c678dd;
+}
+
+.elmsh7 {
+  color: #abb2bf;
 }"""


### PR DESCRIPTION
I thought that adding section about running demo locally is a good idea so I've created one using [elm-live](https://github.com/tomekwi/elm-live).

This PR adds [Atom One Dark](https://github.com/atom/one-dark-syntax) theme. Creating it I discovered that a lot of syntax is overlapping. It's making theming harder because in One Dark for example I want special styling on number literals and right now number literal class is shared with others. I thought that leaner styles would be better and highlight.js themes could be overkill ( #1 ) but after implementing one myself I think we can take a look at their themes and extract syntax constructs like comments, string literals, function names etc and apply styles based on that the same way highlight.js is doing it.