### PR TITLE
Add SQL language support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 elm-stuff
 .DS_Store
+.idea
 demo/elm-themes.js
 demo/themes.html
 elm.js

--- a/demo/Main.elm
+++ b/demo/Main.elm
@@ -74,6 +74,7 @@ initLanguagesModel =
         , ( "Javascript", initLanguageModel javascriptExample )
         , ( "Css", initLanguageModel cssExample )
         , ( "Python", initLanguageModel pythonExample )
+        , ( "Sql", initLanguageModel sqlExample )
         ]
 
 
@@ -199,6 +200,21 @@ class Dog(Animal):
         self.name = name
 
 d = Dog('Fido')
+"""
+
+
+sqlExample : String
+sqlExample =
+    """/*
+ * multi-line comment
+ */
+SELECT a, b, m.*
+  from w.t,
+       w.t2 AS m
+ WHERE a = avg(b)
+    or b != 0x1aB5
+   and c is True
+   AND m.key is in ['key\\'1','key2'];
 """
 
 
@@ -336,6 +352,7 @@ view model =
         , viewLanguage "Xml" toHtmlXml model
         , viewLanguage "Css" toHtmlCss model
         , viewLanguage "Python" toHtmlPython model
+        , viewLanguage "Sql" toHtmlSql model
         , viewOptions model
         ]
 
@@ -460,6 +477,11 @@ toHtmlCss =
 toHtmlPython : Maybe Int -> String -> HighlightModel -> Html Msg
 toHtmlPython =
     toHtml SH.python
+
+
+toHtmlSql : Maybe Int -> String -> HighlightModel -> Html Msg
+toHtmlSql =
+    toHtml SH.sql
 
 
 toHtml : (String -> Result (List Parser.DeadEnd) SH.HCode) -> Maybe Int -> String -> HighlightModel -> Html Msg

--- a/demo/elm.json
+++ b/demo/elm.json
@@ -1,7 +1,8 @@
 {
     "type": "application",
     "source-directories": [
-        "."
+        ".",
+	".."
     ],
     "elm-version": "0.19.0",
     "dependencies": {
@@ -12,8 +13,7 @@
             "elm/json": "1.0.0",
             "elm/parser": "1.1.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0",
-            "pablohirafuji/elm-syntax-highlight": "3.0.0"
+            "elm/time": "1.0.0"
         },
         "indirect": {
             "elm/url": "1.0.0",

--- a/demo/elm.json
+++ b/demo/elm.json
@@ -11,6 +11,7 @@
             "elm/html": "1.0.0",
             "elm/json": "1.0.0",
             "elm/parser": "1.1.0",
+            "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "pablohirafuji/elm-syntax-highlight": "3.0.0"
         },

--- a/elm.json
+++ b/elm.json
@@ -11,7 +11,8 @@
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
-        "elm/parser": "1.1.0 <= v < 2.0.0"
+        "elm/parser": "1.1.0 <= v < 2.0.0",
+        "elm/regex": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.1.0 <= v < 2.0.0"

--- a/src/SyntaxHighlight.elm
+++ b/src/SyntaxHighlight.elm
@@ -2,7 +2,7 @@ module SyntaxHighlight exposing
     ( HCode
     , toBlockHtml, toInlineHtml, toStaticBlockHtml, toStaticInlineHtml
     , Highlight(..), highlightLines
-    , css, elm, javascript, python, xml
+    , css, elm, javascript, python, sql, xml
     , Theme, useTheme, monokai, gitHub, oneDark
     , ConsoleOptions, toConsole
     )
@@ -26,7 +26,7 @@ module SyntaxHighlight exposing
 
 Error while parsing should not happen. If it happens, please [open an issue](https://github.com/pablohirafuji/elm-syntax-highlight/issues) with the code that gives the error and the language.
 
-@docs css, elm, javascript, python, xml
+@docs css, elm, javascript, python, sql, xml
 
 
 ## Themes
@@ -46,6 +46,7 @@ import SyntaxHighlight.Language.Css as Css
 import SyntaxHighlight.Language.Elm as Elm
 import SyntaxHighlight.Language.Javascript as Javascript
 import SyntaxHighlight.Language.Python as Python
+import SyntaxHighlight.Language.Sql as Sql
 import SyntaxHighlight.Language.Xml as Xml
 import SyntaxHighlight.Line as Line exposing (Highlight, Line)
 import SyntaxHighlight.Theme as Theme
@@ -181,6 +182,14 @@ css =
 python : String -> Result (List Parser.DeadEnd) HCode
 python =
     Python.toLines
+        >> Result.map HCode
+
+
+{-| Parse SQL syntax.
+-}
+sql : String -> Result (List Parser.DeadEnd) HCode
+sql =
+    Sql.toLines
         >> Result.map HCode
 
 

--- a/src/SyntaxHighlight/Language/Sql.elm
+++ b/src/SyntaxHighlight/Language/Sql.elm
@@ -1,0 +1,330 @@
+module SyntaxHighlight.Language.Sql exposing
+    ( Syntax(..)
+    ,  syntaxToStyle
+       -- Exposing for test purposes
+
+    , toLines
+    , toRevTokens
+    )
+
+import Parser exposing ((|.), DeadEnd, Parser, Step(..), andThen, backtrackable, getChompedString, loop, map, oneOf, succeed, symbol)
+import Regex exposing (Regex)
+import Set exposing (Set)
+import SyntaxHighlight.Language.Helpers exposing (Delimiter, chompIfThenWhile, delimited, escapable, isEscapable, isLineBreak, isSpace, isWhitespace, thenChompWhile)
+import SyntaxHighlight.Language.Type as T
+import SyntaxHighlight.Line exposing (Line)
+import SyntaxHighlight.Line.Helpers as Line
+import SyntaxHighlight.Style as Style exposing (Required(..))
+
+
+type alias Token =
+    T.Token Syntax
+
+
+type Syntax
+    = Number
+    | String
+    | Keyword
+    | Operator
+    | Function
+    | Punctuation
+    | Literal
+
+
+toLines : String -> Result (List DeadEnd) (List Line)
+toLines =
+    Parser.run toRevTokens
+        >> Result.map (Line.toLines syntaxToStyle)
+
+
+toRevTokens : Parser (List Token)
+toRevTokens =
+    loop [] mainLoop
+
+
+mainLoop : List Token -> Parser (Step (List Token) (List Token))
+mainLoop revTokens =
+    oneOf
+        [ space
+            |> map (\n -> Loop (n :: revTokens))
+        , lineBreak
+            |> map (\n -> Loop (n :: revTokens))
+        , punctuationChar
+            |> map (\n -> Loop (n :: revTokens))
+        , number
+            |> map (\n -> Loop (n :: revTokens))
+        , comment
+            |> map (\n -> Loop (n ++ revTokens))
+        , stringLiteral
+            |> andThen (\n -> loop (n ++ revTokens) stringBody)
+            |> map Loop
+        , chompIfThenWhile isIdentifierChar
+            |> getChompedString
+            |> andThen (keywordParser revTokens)
+            |> map Loop
+        , succeed (Done revTokens)
+        ]
+
+
+isIdentifierChar : Char -> Bool
+isIdentifierChar c =
+    not
+        (isWhitespace c
+            || isPunctuationChar c
+        )
+
+
+stringBody : List Token -> Parser (Step (List Token) (List Token))
+stringBody revTokens =
+    oneOf
+        [ whitespaceOrCommentStep revTokens
+        , stringLiteral |> map (\s -> Loop (s ++ revTokens))
+        , succeed (Done revTokens)
+        ]
+
+
+punctuationChar : Parser Token
+punctuationChar =
+    chompIfThenWhile isPunctuationChar
+        |> getChompedString
+        |> map (\b -> ( T.C Punctuation, b ))
+
+
+isPunctuationChar : Char -> Bool
+isPunctuationChar c =
+    Set.member c punctuatorSet
+
+
+punctuatorSet : Set Char
+punctuatorSet =
+    Set.fromList [ ';', '[', ']', '(', ')', '`', ',', '.' ]
+
+
+
+-- Keywords
+
+
+keywordParser : List Token -> String -> Parser (List Token)
+keywordParser revTokens s =
+    if isOperator s then
+        succeed (( T.C Operator, s ) :: revTokens)
+
+    else if isFunction s then
+        succeed (( T.C Function, s ) :: revTokens)
+
+    else if isKeyword s then
+        succeed (( T.C Keyword, s ) :: revTokens)
+
+    else if isLiteral s then
+        succeed (( T.C Literal, s ) :: revTokens)
+
+    else
+        succeed (( T.Normal, s ) :: revTokens)
+
+
+isKeyword : String -> Bool
+isKeyword =
+    Regex.contains keywordPattern
+
+
+keywordPattern : Regex
+keywordPattern =
+    "^(ACTION|ADD|AFTER|ALGORITHM|ALL|ALTER|ANALYZE|ANY|APPLY|AS|ASC|AUTHORIZATION|AUTO_INCREMENT|BACKUP|BDB|BEGIN|BERKELEYDB|BIGINT|BINARY|BIT|BLOB|BOOL|BOOLEAN|BREAK|BROWSE|BTREE|BULK|BY|CALL|CASCADED?|CASE|CHAIN|CHAR(?:ACTER|SET)?|CHECK(?:POINT)?|CLOSE|CLUSTERED|COALESCE|COLLATE|COLUMNS?|COMMENT|COMMIT(?:TED)?|COMPUTE|CONNECT|CONSISTENT|CONSTRAINT|CONTAINS(?:TABLE)?|CONTINUE|CONVERT|CREATE|CROSS|CURRENT(?:_DATE|_TIME|_TIMESTAMP|_USER)?|CURSOR|CYCLE|DATA(?:BASES?)?|DATE(?:TIME)?|DAY|DBCC|DEALLOCATE|DEC|DECIMAL|DECLARE|DEFAULT|DEFINER|DELAYED|DELETE|DELIMITERS?|DENY|DESC|DESCRIBE|DETERMINISTIC|DISABLE|DISCARD|DISK|DISTINCT|DISTINCTROW|DISTRIBUTED|DO|DOUBLE|DROP|DUMMY|DUMP(?:FILE)?|DUPLICATE|ELSE(?:IF)?|ENABLE|ENCLOSED|END|ENGINE|ENUM|ERRLVL|ERRORS|ESCAPED?|EXCEPT|EXEC(?:UTE)?|EXISTS|EXIT|EXPLAIN|EXTENDED|FETCH|FIELDS|FILE|FILLFACTOR|FIRST|FIXED|FLOAT|FOLLOWING|FOR(?: EACH ROW)?|FORCE|FOREIGN|FREETEXT(?:TABLE)?|FROM|FULL|FUNCTION|GEOMETRY(?:COLLECTION)?|GLOBAL|GOTO|GRANT|GROUP|HANDLER|HASH|HAVING|HOLDLOCK|HOUR|IDENTITY(?:_INSERT|COL)?|IF|IGNORE|IMPORT|INDEX|INFILE|INNER|INNODB|INOUT|INSERT|INT|INTEGER|INTERSECT|INTERVAL|INTO|INVOKER|ISOLATION|ITERATE|JOIN|KEYS?|KILL|LANGUAGE|LAST|LEAVE|LEFT|LEVEL|LIMIT|LINENO|LINES|LINESTRING|LOAD|LOCAL|LOCK|LONG(?:BLOB|TEXT)|LOOP|MATCH(?:ED)?|MEDIUM(?:BLOB|INT|TEXT)|MERGE|MIDDLEINT|MINUTE|MODE|MODIFIES|MODIFY|MONTH|MULTI(?:LINESTRING|POINT|POLYGON)|NATIONAL|NATURAL|NCHAR|NEXT|NO|NONCLUSTERED|NULLIF|NUMERIC|OFF?|OFFSETS?|ON|OPEN(?:DATASOURCE|QUERY|ROWSET)?|OPTIMIZE|OPTION(?:ALLY)?|ORDER|OUT(?:ER|FILE)?|OVER|PARTIAL|PARTITION|PERCENT|PIVOT|PLAN|POINT|POLYGON|PRECEDING|PRECISION|PREPARE|PREV|PRIMARY|PRINT|PRIVILEGES|PROC(?:EDURE)?|PUBLIC|PURGE|QUICK|RAISERROR|READS?|REAL|RECONFIGURE|REFERENCES|RELEASE|RENAME|REPEAT(?:ABLE)?|REPLACE|REPLICATION|REQUIRE|RESIGNAL|RESTORE|RESTRICT|RETURNS?|REVOKE|RIGHT|ROLLBACK|ROUTINE|ROW(?:COUNT|GUIDCOL|S)?|RTREE|RULE|SAVE(?:POINT)?|SCHEMA|SECOND|SELECT|SERIAL(?:IZABLE)?|SESSION(?:_USER)?|SET(?:USER)?|SHARE|SHOW|SHUTDOWN|SIMPLE|SMALLINT|SNAPSHOT|SOME|SONAME|SQL|START(?:ING)?|STATISTICS|STATUS|STRIPED|SYSTEM_USER|TABLES?|TABLESPACE|TEMP(?:ORARY|TABLE)?|TERMINATED|TEXT(?:SIZE)?|THEN|TIME(?:STAMP)?|TINY(?:BLOB|INT|TEXT)|TOP?|TRAN(?:SACTIONS?)?|TRIGGER|TRUNCATE|TSEQUAL|TYPES?|UNBOUNDED|UNCOMMITTED|UNDEFINED|UNION|UNIQUE|UNLOCK|UNPIVOT|UNSIGNED|UPDATE(?:TEXT)?|USAGE|USE|USER|USING|VALUES?|VAR(?:BINARY|CHAR|CHARACTER|YING)|VIEW|WAITFOR|WARNINGS|WHEN|WHERE|WHILE|WITH(?: ROLLUP|IN)?|WORK|WRITE(?:TEXT)?|YEAR)$"
+        |> Regex.fromStringWith { caseInsensitive = True, multiline = False }
+        |> Maybe.withDefault Regex.never
+
+
+isLiteral : String -> Bool
+isLiteral str =
+    Set.member (String.toUpper str) literalSet
+
+
+literalSet : Set String
+literalSet =
+    Set.fromList [ "TRUE", "FALSE", "NULL" ]
+
+
+isFunction : String -> Bool
+isFunction str =
+    Set.member (String.toUpper str) functionSet
+
+
+functionSet : Set String
+functionSet =
+    Set.fromList [ "AVG", "COUNT", "FIRST", "FORMAT", "LAST", "LCASE", "LEN", "MAX", "MID", "MIN", "MOD", "NOW", "ROUND", "SUM", "UCASE" ]
+
+
+isOperator : String -> Bool
+isOperator =
+    Regex.contains operatorPattern
+
+
+operatorPattern : Regex
+operatorPattern =
+    "^([-+*\\/=%^~]|&&?|\\|\\|?|!=?|<(?:=>?|<|>)?|>[>=]?|AND|BETWEEN|IN|LIKE|NOT|OR|IS|DIV|REGEXP|RLIKE|SOUNDS LIKE|XOR)$"
+        |> Regex.fromStringWith { caseInsensitive = True, multiline = False }
+        |> Maybe.withDefault Regex.never
+
+
+
+-- Strings
+
+
+stringLiteral : Parser (List Token)
+stringLiteral =
+    oneOf
+        [ quote
+        , doubleQuote
+        ]
+
+
+quote : Parser (List Token)
+quote =
+    delimited quoteDelimiter
+
+
+quoteDelimiter : Delimiter Token
+quoteDelimiter =
+    { start = "'"
+    , end = "'"
+    , isNestable = False
+    , defaultMap = \b -> ( T.C String, b )
+    , innerParsers = [ lineBreakList, sqlEscapable ]
+    , isNotRelevant = \c -> not (isLineBreak c || isEscapable c)
+    }
+
+
+doubleQuote : Parser (List Token)
+doubleQuote =
+    delimited
+        { quoteDelimiter
+            | start = "\""
+            , end = "\""
+        }
+
+
+isStringLiteralChar : Char -> Bool
+isStringLiteralChar c =
+    c == '\'' || c == '"'
+
+
+
+-- Comments
+
+
+comment : Parser (List Token)
+comment =
+    oneOf
+        [ inlineComment
+        , multilineComment
+        ]
+
+
+inlineComment : Parser (List Token)
+inlineComment =
+    [ "--", "$", "#" ]
+        |> List.map (symbol >> thenChompWhile (not << isLineBreak) >> getChompedString >> map (\b -> [ ( T.Comment, b ) ]))
+        |> oneOf
+
+
+multilineComment : Parser (List Token)
+multilineComment =
+    delimited
+        { start = "/*"
+        , end = "*/"
+        , isNestable = False
+        , defaultMap = \b -> ( T.Comment, b )
+        , innerParsers = [ lineBreakList ]
+        , isNotRelevant = not << isLineBreak
+        }
+
+
+
+-- Helpers
+
+
+whitespaceOrCommentStep : List Token -> Parser (Step (List Token) (List Token))
+whitespaceOrCommentStep revTokens =
+    oneOf
+        [ space |> map (\s -> Loop (s :: revTokens))
+        , lineBreak
+            |> map (\s -> s :: revTokens)
+            |> andThen checkContext
+        , comment |> map (\s -> Loop (s ++ revTokens))
+        ]
+
+
+checkContext : List Token -> Parser (Step (List Token) (List Token))
+checkContext revTokens =
+    oneOf
+        [ whitespaceOrCommentStep revTokens
+        , succeed (Done revTokens)
+        ]
+
+
+space : Parser Token
+space =
+    chompIfThenWhile isSpace
+        |> getChompedString
+        |> map (\b -> ( T.Normal, b ))
+
+
+lineBreak : Parser Token
+lineBreak =
+    symbol "\n"
+        |> map (\_ -> ( T.LineBreak, "\n" ))
+
+
+lineBreakList : Parser (List Token)
+lineBreakList =
+    symbol "\n"
+        |> map (\_ -> [ ( T.LineBreak, "\n" ) ])
+
+
+number : Parser Token
+number =
+    oneOf
+        [ hexNumber
+        , SyntaxHighlight.Language.Helpers.number
+        ]
+        |> getChompedString
+        |> map (\b -> ( T.C Number, b ))
+
+
+hexNumber : Parser ()
+hexNumber =
+    succeed ()
+        |. backtrackable (symbol "0x")
+        |. chompIfThenWhile Char.isHexDigit
+
+
+sqlEscapable : Parser (List Token)
+sqlEscapable =
+    escapable
+        |> getChompedString
+        |> map (\b -> [ ( T.C Function, b ) ])
+
+
+syntaxToStyle : Syntax -> ( Style.Required, String )
+syntaxToStyle syntax =
+    case syntax of
+        Number ->
+            ( Style1, "sql-n" )
+
+        String ->
+            ( Style2, "sql-s" )
+
+        Keyword ->
+            ( Style3, "sql-k" )
+
+        Operator ->
+            ( Style4, "sql-o" )
+
+        Function ->
+            ( Style5, "sql-f" )
+
+        Punctuation ->
+            ( Style6, "sql-p" )
+
+        Literal ->
+            ( Style7, "sql-l" )

--- a/src/SyntaxHighlight/Line.elm
+++ b/src/SyntaxHighlight/Line.elm
@@ -1,10 +1,7 @@
-module SyntaxHighlight.Line
-    exposing
-        ( Fragment
-        , Highlight(..)
-        , Line
-        , highlightLines
-        )
+module SyntaxHighlight.Line exposing
+    ( Line, Fragment, Highlight(..)
+    , highlightLines
+    )
 
 {-| A parsed highlighted line.
 

--- a/src/SyntaxHighlight/Line/Helpers.elm
+++ b/src/SyntaxHighlight/Line/Helpers.elm
@@ -1,7 +1,4 @@
-module SyntaxHighlight.Line.Helpers
-    exposing
-        ( toLines
-        )
+module SyntaxHighlight.Line.Helpers exposing (toLines)
 
 import SyntaxHighlight.Language.Type as T exposing (Syntax(..), Token)
 import SyntaxHighlight.Line exposing (Fragment, Line)

--- a/src/SyntaxHighlight/Style.elm
+++ b/src/SyntaxHighlight/Style.elm
@@ -1,4 +1,4 @@
-module SyntaxHighlight.Style exposing (..)
+module SyntaxHighlight.Style exposing (Color(..), Required(..), RequiredStyles, Style, backgroundColor, bold, colorToCss, emptyIfFalse, italic, noEmphasis, styleToCss, textColor, toCss, toCssClass)
 
 {-
    The common uses of the styles are the following:

--- a/src/SyntaxHighlight/Theme.elm
+++ b/src/SyntaxHighlight/Theme.elm
@@ -1,10 +1,9 @@
-module SyntaxHighlight.Theme
-    exposing
-        ( all
-        , gitHub
-        , monokai
-        , oneDark
-        )
+module SyntaxHighlight.Theme exposing
+    ( all
+    , gitHub
+    , monokai
+    , oneDark
+    )
 
 import SyntaxHighlight.Theme.GitHub as GitHub
 import SyntaxHighlight.Theme.Monokai as Monokai

--- a/src/SyntaxHighlight/Theme/Type.elm
+++ b/src/SyntaxHighlight/Theme/Type.elm
@@ -4,6 +4,7 @@ import SyntaxHighlight.Language.Css as Css
 import SyntaxHighlight.Language.Elm as Elm
 import SyntaxHighlight.Language.Javascript as Javascript
 import SyntaxHighlight.Language.Python as Python
+import SyntaxHighlight.Language.Sql as Sql
 import SyntaxHighlight.Language.Xml as Xml
 import SyntaxHighlight.Style as Style exposing (RequiredStyles, Style)
 
@@ -20,6 +21,7 @@ type Syntax
     | Javascript Javascript.Syntax
     | Css Css.Syntax
     | Python Python.Syntax
+    | Sql Sql.Syntax
 
 
 toCss : Theme -> String
@@ -70,4 +72,8 @@ syntaxToSelector syntax =
 
         Python pythonSyntax ->
             Python.syntaxToStyle pythonSyntax
+                |> Tuple.second
+
+        Sql sqlSyntax ->
+            Sql.syntaxToStyle sqlSyntax
                 |> Tuple.second

--- a/tests/Language/Sql.elm
+++ b/tests/Language/Sql.elm
@@ -1,0 +1,24 @@
+module Language.Sql exposing (suite)
+
+import Expect exposing (Expectation, equal, equalLists, onFail)
+import Fuzz exposing (string)
+import Parser
+import Result exposing (Result(..))
+import SyntaxHighlight.Language.Sql as Sql exposing (Syntax(..), toRevTokens)
+import Test exposing (..)
+
+
+suite : Test
+suite =
+    describe "SQL Language Test Suite"
+        [ fuzz string "Fuzz string" <|
+            \fuzzStr ->
+                Parser.run Sql.toRevTokens fuzzStr
+                    |> Result.map
+                        (List.reverse
+                            >> List.map Tuple.second
+                            >> String.concat
+                        )
+                    |> equal (Ok fuzzStr)
+                    |> onFail ("Resulting error string: \"" ++ fuzzStr ++ "\"")
+        ]


### PR DESCRIPTION
Hi @pablohirafuji,

Love your library. I was hoping to add SQL language support to it. Please review my changes though. 

One part I'm particularly concerned about is the use of regular expressions to identify keywords. The whole idea of the elm/parser library is to avoid using regex... but it was the quickest way of implementing SQL syntax highlighting as I was basing my changes on PrismJS.