### PR TITLE
Added support for error tokens, and their corresponding style.

### DIFF
--- a/src/SyntaxHighlight.elm
+++ b/src/SyntaxHighlight.elm
@@ -301,6 +301,7 @@ type alias ConsoleOptions =
     , style5 : String -> String
     , style6 : String -> String
     , style7 : String -> String
+    , error : String -> String
     }
 
 
@@ -323,6 +324,7 @@ toConsole options =
         , style5 = options.style5
         , style6 = options.style6
         , style7 = options.style7
+        , error = options.error
         }
 
 
@@ -358,6 +360,7 @@ type alias CustomTransform fragment line =
     , style5 : String -> fragment
     , style6 : String -> fragment
     , style7 : String -> fragment
+    , error : String -> fragment
     }
 
 
@@ -415,3 +418,6 @@ toCustomFragment options { text, requiredStyle, additionalClass } =
 
         Style.Style7 ->
             options.style7 text
+
+        Style.StyleError ->
+            options.error text

--- a/src/SyntaxHighlight/Language/Helpers.elm
+++ b/src/SyntaxHighlight/Language/Helpers.elm
@@ -11,6 +11,7 @@ module SyntaxHighlight.Language.Helpers exposing
     , isSpace
     , isWhitespace
     , number
+    , numberExponentialNotation
     , thenChompWhile
     , whitespaceCharSet
     )
@@ -42,6 +43,28 @@ isSpace c =
 isLineBreak : Char -> Bool
 isLineBreak c =
     c == '\n'
+
+
+numberExponentialNotation : Parser ()
+numberExponentialNotation =
+    oneOf
+        [ positiveNumberExponentialNotation
+        , negativeNumberExponentialNotation
+        , number
+        ]
+
+
+negativeNumberExponentialNotation : Parser ()
+negativeNumberExponentialNotation =
+    succeed ()
+        |. backtrackable (symbol "-")
+        |. positiveNumberExponentialNotation
+
+
+positiveNumberExponentialNotation : Parser ()
+positiveNumberExponentialNotation =
+    succeed ()
+        |. backtrackable float
 
 
 number : Parser ()

--- a/src/SyntaxHighlight/Language/Json.elm
+++ b/src/SyntaxHighlight/Language/Json.elm
@@ -9,7 +9,7 @@ module SyntaxHighlight.Language.Json exposing
 
 import Parser exposing ((|.), DeadEnd, Parser, Step(..), andThen, chompIf, getChompedString, keyword, loop, map, oneOf, succeed, symbol)
 import Set exposing (Set)
-import SyntaxHighlight.Language.Helpers exposing (Delimiter, chompIfThenWhile, delimited, isEscapable, isLineBreak, isSpace, isWhitespace, thenChompWhile, whitespaceCharSet)
+import SyntaxHighlight.Language.Helpers exposing (Delimiter, chompIfThenWhile, delimited, isEscapable, isLineBreak, isSpace)
 import SyntaxHighlight.Language.Type as T
 import SyntaxHighlight.Line exposing (Line)
 import SyntaxHighlight.Line.Helpers as Line
@@ -29,6 +29,7 @@ type Syntax
     | ObjectKey
     | Object
     | Array
+    | Error
 
 
 toLines : String -> Result (List DeadEnd) (List Line)
@@ -51,7 +52,7 @@ mainLoop revTokens =
             |> map (\n -> Loop (n ++ revTokens))
         , chompIf (always True)
             |> getChompedString
-            |> map (\b -> Loop (( T.Normal, b ) :: revTokens))
+            |> map (\b -> Loop (( T.C Error, b ) :: revTokens))
         , succeed (Done revTokens)
         ]
 
@@ -264,3 +265,6 @@ syntaxToStyle syntax =
 
         Array ->
             ( Default, "json-a" )
+
+        Error ->
+            ( StyleError, "json-e" )

--- a/src/SyntaxHighlight/Language/Json.elm
+++ b/src/SyntaxHighlight/Language/Json.elm
@@ -199,7 +199,7 @@ lineBreak =
 
 number : Parser Token
 number =
-    SyntaxHighlight.Language.Helpers.number
+    SyntaxHighlight.Language.Helpers.numberExponentialNotation
         |> getChompedString
         |> map (\b -> ( T.C Number, b ))
 

--- a/src/SyntaxHighlight/Style.elm
+++ b/src/SyntaxHighlight/Style.elm
@@ -25,6 +25,7 @@ type Required
     | Style5
     | Style6
     | Style7
+    | StyleError
 
 
 type alias RequiredStyles =
@@ -40,6 +41,7 @@ type alias RequiredStyles =
     , style5 : Style
     , style6 : Style
     , style7 : Style
+    , error : Style
     }
 
 

--- a/src/SyntaxHighlight/Theme/GitHub.elm
+++ b/src/SyntaxHighlight/Theme/GitHub.elm
@@ -34,4 +34,5 @@ requiredStyles =
     , style5 = textColor (Hex "#63a35c")
     , style6 = textColor (Hex "#005cc5")
     , style7 = textColor (Hex "#795da3")
+    , error = backgroundColor (Hex "#f8c8c8")
     }

--- a/src/SyntaxHighlight/Theme/Monokai.elm
+++ b/src/SyntaxHighlight/Theme/Monokai.elm
@@ -4,7 +4,7 @@ import SyntaxHighlight.Language.Css as Css
 import SyntaxHighlight.Language.Elm as Elm
 import SyntaxHighlight.Language.Javascript as JS
 import SyntaxHighlight.Style exposing (Color(..), RequiredStyles, backgroundColor, bold, italic, noEmphasis, textColor)
-import SyntaxHighlight.Theme.Type as Type exposing (Syntax(..), Theme, toCss)
+import SyntaxHighlight.Theme.Type exposing (Syntax(..), Theme, toCss)
 
 
 
@@ -50,4 +50,5 @@ requiredStyles =
     , style5 = textColor (Hex "#a6e22e")
     , style6 = textColor (Hex "#ae81ff")
     , style7 = textColor (Hex "#fd971f")
+    , error = backgroundColor (Hex "#f92472")
     }

--- a/src/SyntaxHighlight/Theme/OneDark.elm
+++ b/src/SyntaxHighlight/Theme/OneDark.elm
@@ -51,4 +51,5 @@ requiredStyles =
     , style5 = textColor (Hex "#61aeee")
     , style6 = textColor (Hex "#d19a66")
     , style7 = textColor (Hex "#abb2bf")
+    , error = textColor (Hex "#ff0000")
     }

--- a/src/SyntaxHighlight/Theme/Type.elm
+++ b/src/SyntaxHighlight/Theme/Type.elm
@@ -40,6 +40,7 @@ toCss { requiredStyles, customStyles } =
     , ( ".elmsh5", requiredStyles.style5 )
     , ( ".elmsh6", requiredStyles.style6 )
     , ( ".elmsh7", requiredStyles.style7 )
+    , ( ".elmsh-err", requiredStyles.error )
     ]
         ++ List.map (Tuple.mapFirst syntaxesToSelectors) customStyles
         |> Style.toCss

--- a/src/SyntaxHighlight/View.elm
+++ b/src/SyntaxHighlight/View.elm
@@ -1,6 +1,6 @@
 module SyntaxHighlight.View exposing (toBlockHtml, toInlineHtml, toStaticBlockHtml, toStaticInlineHtml)
 
-import Html exposing (Html, br, code, div, pre, span, text)
+import Html exposing (Html, code, div, pre, span, text)
 import Html.Attributes exposing (attribute, class, classList)
 import SyntaxHighlight.Line exposing (..)
 import SyntaxHighlight.Style exposing (Required(..))
@@ -111,6 +111,9 @@ requiredStyleToString required =
 
             Style7 ->
                 "7"
+
+            StyleError ->
+                "-err"
 
 
 

--- a/tests/Language/Json.elm
+++ b/tests/Language/Json.elm
@@ -12,7 +12,11 @@ import Test exposing (..)
 suite : Test
 suite =
     describe "JSON Language Test Suite"
-        [ numberTest "integer zero" "0"
+        [ equalTest "simple object" "{\"lang\":\"JSON\"}"
+            ( Ok [(C Object,"{"),(C ObjectKey,"\""),(C ObjectKey,"lang"),(C ObjectKey,"\""),(C Object,":"),(C String,"\""),(C String,"JSON"),(C String,"\""),(C Object,"}")] )
+        , equalTest "invalid value" "{\"lang\":JSON}"
+            ( Ok [(C Object,"{"),(C ObjectKey,"\""),(C ObjectKey,"lang"),(C ObjectKey,"\""),(C Object,":"),(C Error,"J"),(C Error,"S"),(C Error,"O"),(C Error,"N"),(C Error,"}")] )
+        , numberTest "integer zero" "0"
         , numberTest "decimal zero" "0.0"
         , numberTest "life, the universe, everything" "42"
         , numberTest "negative value" "-1"

--- a/tests/Language/Json.elm
+++ b/tests/Language/Json.elm
@@ -5,13 +5,26 @@ import Fuzz exposing (string)
 import Parser
 import Result exposing (Result(..))
 import SyntaxHighlight.Language.Json as Json exposing (Syntax(..), toRevTokens)
+import SyntaxHighlight.Language.Type as T exposing (Syntax(..))
 import Test exposing (..)
 
 
 suite : Test
 suite =
     describe "JSON Language Test Suite"
-        [ fuzz string "Fuzz string" <|
+        [ numberTest "integer zero" "0"
+        , numberTest "decimal zero" "0.0"
+        , numberTest "life, the universe, everything" "42"
+        , numberTest "negative value" "-1"
+        , numberTest "negative decimal" "-1.2345"
+        , numberTest "Euler's number" "2.71828"
+        , numberTest "Avogadro's number exponent (E) notation" "6.0221409E23"
+        , numberTest "Avogadro's number exponent (e) notation" "6.0221409e23"
+        , numberTest "Avogadro's number exponent (E+) notation" "6.0221409E+23"
+        , numberTest "Avogadro's number exponent (e+) notation" "6.0221409e+23"
+        , numberTest "Gauss' constant exponent (E) notation" "8.346268E-1"
+        , numberTest "Gauss' constant exponent (e) notation" "8.346268e-1"
+        , fuzz string "Fuzz string" <|
             \fuzzStr ->
                 Parser.run Json.toRevTokens fuzzStr
                     |> Result.map
@@ -21,4 +34,33 @@ suite =
                         )
                     |> equal (Ok fuzzStr)
                     |> onFail ("Resulting error string: \"" ++ fuzzStr ++ "\"")
+        ]
+
+
+numberTest : String -> String -> Test
+numberTest testName testStr =
+    describe ("Number :" ++ testName)
+        [ equalTest "number"
+            ( "{\"number\": " ++ testStr ++ "}" )
+            ( Ok [(C Object,"{"),(C ObjectKey,"\""),(C ObjectKey,"number"),(C ObjectKey,"\""),(C Object,":"),(Normal," "),(C Number,testStr),(C Object,"}")])
+        ]
+
+
+equalTest : String -> String -> Result (List Parser.DeadEnd) (List ( T.Syntax Json.Syntax, String )) -> Test
+equalTest testName testStr testResult =
+    describe testName
+        [ test "Syntax equality" <|
+            \() ->
+                Parser.run Json.toRevTokens testStr
+                    |> Result.map List.reverse
+                    |> equal testResult
+        , test "String equality" <|
+            \() ->
+                Parser.run Json.toRevTokens testStr
+                    |> Result.map
+                        (List.reverse
+                            >> List.map Tuple.second
+                            >> String.concat
+                        )
+                    |> equal (Ok testStr)
         ]


### PR DESCRIPTION
Thanks for reviewing and accepting my PR so quickly last week.

I was thinking it would be a good idea to be able to parse "error"/"unexpected" tokens, and rendering them accordingly. For instance:
![image](https://user-images.githubusercontent.com/596034/129457228-023bfd5e-bbeb-4586-bd16-f6de53bfba01.png)

We can even get more sophisticated with error rendering, by defining a custom theme like:
```css
.elmsh-err {
  border-bottom:2px dotted red;
  margin-bottom:-2px;
  display: inline-block;
  position: relative;
}
.elmsh-err:after {
  content: '';
  width: 100%;
  border-bottom:2px dotted red;
  position: absolute;
  bottom:-1px;
  left: -2px;
}
```

Which would produce this:
![image](https://user-images.githubusercontent.com/596034/129457293-8a27044d-1c60-4c60-b0ce-1f3b0b067492.png)

If this looks good to you, I'll work on a separate PR updating the `Theme`/`Style` types including something like:
```elm
squiggly : Color -> Style -> Style
```
That generates Styles for the squiggly example above.

Let me know what you think.