### PR TITLE
Fix scrolling in demo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ```shell
 cd demo
-elm-reactor
+elm reactor
 ```
 
 Demo will be available at http://localhost:8000/index.html

--- a/demo/src/Main.elm
+++ b/demo/src/Main.elm
@@ -54,8 +54,8 @@ initModel =
 
 
 type alias Scroll =
-    { top : Int
-    , left : Int
+    { top : Float
+    , left : Float
     }
 
 
@@ -514,9 +514,9 @@ viewLanguage thisLang parser ({ currentLanguage, lineCount } as model) =
                 [ class "view-container"
                 , style "transform"
                     ("translate("
-                        ++ String.fromInt -langModel.scroll.left
+                        ++ String.fromFloat -langModel.scroll.left
                         ++ "px, "
-                        ++ String.fromInt -langModel.scroll.top
+                        ++ String.fromFloat -langModel.scroll.top
                         ++ "px)"
                     )
                 , style "will-change" "transform"
@@ -542,8 +542,8 @@ viewTextarea thisLang codeStr { showLineCount } =
         , spellcheck False
         , Html.Events.on "scroll"
             (Json.map2 Scroll
-                (Json.at [ "target", "scrollTop" ] Json.int)
-                (Json.at [ "target", "scrollLeft" ] Json.int)
+                (Json.at [ "target", "scrollTop" ] Json.float)
+                (Json.at [ "target", "scrollLeft" ] Json.float)
                 |> Json.map OnScroll
             )
         ]


### PR DESCRIPTION
Thank you for this project!

We have adapted the code from the demo and found a small scrolling issue in Chrome (Linux).

The demo app tries to parse the scroll position as integers, but they may be floats. If they are floats, parsing the event data fails and the event is silently discarded, so the `OnScroll` message is lost. When using floats for scroll positions there is no issue.

https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop